### PR TITLE
Add "HEAST" Keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Examples can be found in the [examples](examples) directory.
 | DO IS DA HUND BEGROBN | console.debug |
 | GSCHISSN GRISSN | console.error |
 | DES IS MA ECHT Z'DEPPAT | process.exit |
+| HEAST | alert |
 
 ## License
 This project is licensed under the MIT license, Copyright (c) 2020 David Pichsenmeister | [pichsenmeister.com](https://pichsenmeister.com). For more information see [LICENSE](LICENSE).

--- a/keywords.json
+++ b/keywords.json
@@ -53,4 +53,5 @@
     "HOST MI": "?",
     "DANN HOIT NET": ":",
     "HUACH ZUA": "=>"
+    "HEAST": "alert"
 }

--- a/keywords.json
+++ b/keywords.json
@@ -52,6 +52,6 @@
     "JO EH": "!",
     "HOST MI": "?",
     "DANN HOIT NET": ":",
-    "HUACH ZUA": "=>"
+    "HUACH ZUA": "=>",
     "HEAST": "alert"
 }


### PR DESCRIPTION
No implementation of WIenerScript should be missing the most iconic Viennese interjection.

I've added "HEAST" as an alias for "alert" to not break existing WS sourcecode.
The "alert"-function (while not essential to writing JS code like logical operators or much needed functionality like console.log) is the best fit for the implied urgency of a heartfelt "HEAST!", while being just as easily dismissable.

Example usage:
`HEAST ("Gschissena!")`